### PR TITLE
Fix missing styles when using Nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,8 @@
         '';
         postInstall = ''
           wrapProgram $out/bin/${pname} \
-          	--prefix PATH : ${pkgs.lib.makeBinPath extraPackages}
+          	--prefix PATH : ${pkgs.lib.makeBinPath extraPackages} \
+          	--set AGS2SHELL_DEV $out/share
         '';
       };
     };


### PR DESCRIPTION
`nix run` currently results in the following error:

```
(gjs:4879): Gjs-WARNING **: 16:34:52.453: JS ERROR: Error: Config directory missing
resetCss@file:///run/user/1000/dmFyIF-ags.js:3349:13 -> style/index.ts:92:10
initCss@file:///run/user/1000/dmFyIF-ags.js:3363:9 -> style/index.ts:108:8
init@file:///run/user/1000/dmFyIF-ags.js:3509:3 -> lib/init.ts:58:2
async*main@file:///run/user/1000/dmFyIF-ags.js:6910:5
vfunc_command_line/<@file:///run/user/1000/dmFyIF-ags.js:1859:68
```

This is because the style path is derived from `import.meta.url`:
https://github.com/TheWolfStreet/ags2-shell/blob/edd42d82af4d2d1803cda84b82a84490edf5d08d/style/index.ts#L20

...but `import.meta.url` points to the JS entrypoint in `/run/user/<uid>`, whereas the styles can be found in the directory where the actual package is stored (e.g. `/nix/store/kld9dvwvvwj5q0fd8xn94rv4rq7cx8dn-ags2-shell/share/`). I'm not sure if there is a way to obtain the original location of the `ags2-shell` binary at runtime in JS, but the issue can be fixed by setting the `AGS2SHELL_DEV` env var to point to the correct directory in the derivation.

Also something to consider: I think it would probably be good to rename the env var to something like `AGS2SHELL_STYLES` instead.