### PR TITLE
Update ags/nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758282730,
-        "narHash": "sha256-qoYGVqRtPbwxZhlr4McXxmFnpRCGA8pNIX3fmKgk21Y=",
+        "lastModified": 1764289441,
+        "narHash": "sha256-ak+lgFiYE5PHByN1/BRkO5JP498hno6Ix24C1Qf/vec=",
         "owner": "aylur",
         "repo": "ags",
-        "rev": "aaae4d2b8cce370e6aceb2082b5c248b799c0e4d",
+        "rev": "e169694390548dfd38ff40f1ef2163d6c3ffe3ea",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756474652,
-        "narHash": "sha256-iiBU6itpEqE0spXeNJ3uJTfioSyKYjt5bNepykpDXTE=",
+        "lastModified": 1764173295,
+        "narHash": "sha256-Jh4VtPcK2Ov+RTcV9FtyQRsxiJmXFQGfqX6jjM7/mgc=",
         "owner": "aylur",
         "repo": "astal",
-        "rev": "20bd8318e4136fbd3d4eb2d64dbabc3acbc915dd",
+        "rev": "7d1fac8a4b2a14954843a978d2ddde86168c75ef",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758198701,
-        "narHash": "sha256-7To75JlpekfUmdkUZewnT6MoBANS0XVypW6kjUOXQwc=",
+        "lastModified": 1764517877,
+        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0147c2f1d54b30b5dd6d4a8c8542e8d7edf93b5d",
+        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
         "type": "github"
       },
       "original": {

--- a/widget/Bar/components/Launcher.tsx
+++ b/widget/Bar/components/Launcher.tsx
@@ -3,7 +3,7 @@ import { Accessor, createBinding, createComputed, createState, For, onCleanup } 
 import { Astal, Gtk, Gdk } from "ags/gtk4"
 
 import AstalApps from "gi://AstalApps"
-import Gio from "gi://Gio"
+import GioUnix from "gi://GioUnix"
 
 import { Placeholder } from "widget/shared/Placeholder"
 import { PopupWindow } from "widget/shared/PopupWindow"
@@ -26,12 +26,12 @@ const { CENTER, END } = Gtk.Align
 export namespace Launcher {
 	const allApps = createBinding(apps, "list").as(v => v.get_list())
 	const appRevealers = new Map<string, Gtk.Revealer>()
-	const desktopInfoCache = new Map<string, Gio.DesktopAppInfo | null>()
+	const desktopInfoCache = new Map<string, GioUnix.DesktopAppInfo | null>()
 
-	function getDesktopInfo(app: AstalApps.Application): Gio.DesktopAppInfo | undefined {
+	function getDesktopInfo(app: AstalApps.Application): GioUnix.DesktopAppInfo | undefined {
 		const appName = app.get_name()
 		if (!desktopInfoCache.has(appName)) {
-			desktopInfoCache.set(appName, Gio.DesktopAppInfo.new(app.get_entry()))
+			desktopInfoCache.set(appName, GioUnix.DesktopAppInfo.new(app.get_entry()))
 		}
 		return desktopInfoCache.get(appName) ?? undefined
 	}

--- a/widget/Bar/components/Overview.tsx
+++ b/widget/Bar/components/Overview.tsx
@@ -28,15 +28,7 @@ export namespace Workspaces {
 		const existing_ids = new Set(ws.map(w => w.id))
 		for (let id = 1; id <= total; id++) {
 			if (!existing_ids.has(id)) {
-				ws.push({
-					id,
-					get_id() { return this.id },
-					disconnect() { },
-					connect() { },
-					focus() { hypr.message_async(`dispatch workspace ${this.id}`, null) },
-					clients: [],
-					monitor: undefined,
-				} as any as AstalHyprland.Workspace)
+				ws.push(AstalHyprland.Workspace.dummy(id, null))
 			}
 		}
 		return ws.sort((a, b) => a.id - b.id)


### PR DESCRIPTION
Nixpkgs 25.11 is incompatible with the pinned version of ags/astal due to `wrapGappsHook` deprecation, but this shell is currently incompatible with the latest version of ags. So this updates the flake inputs to their latest versions and fixes any issues I could find.

- Update ags + nixpkgs to latest commit
- Refactor `Gio.DesktopAppInfo` -> `GioUnix.DesktopAppInfo`
- Uses `AstalHyprland.Workspace.dummy` instead of a custom object, because in the latest version of `gnim` you cannot call `createBinding` with a custom object anymore (it must be a `GObject` afaik)
